### PR TITLE
additional faulty replacements seen in the wild

### DIFF
--- a/vipermonkey/core/literals.py
+++ b/vipermonkey/core/literals.py
@@ -120,6 +120,16 @@ class String(VBA_Object):
         self.value = tokens[0]
         # Replace Python control characters.
         self.value = self.value.\
+                     replace("\0","\\0").\
+                     replace("\1","\\1").\
+                     replace("\2","\\2").\
+                     replace("\3","\\3").\
+                     replace("\4","\\4").\
+                     replace("\5","\\5").\
+                     replace("\6","\\6").\
+                     replace("\7","\\7").\
+                     replace("\8","\\8").\
+                     replace("\9","\\9").\
                      replace("\n", "\\n").\
                      replace("\t", "\\t").\
                      replace("\f", "\\f").\

--- a/vipermonkey/core/literals.py
+++ b/vipermonkey/core/literals.py
@@ -128,8 +128,6 @@ class String(VBA_Object):
                      replace("\5","\\5").\
                      replace("\6","\\6").\
                      replace("\7","\\7").\
-                     replace("\8","\\8").\
-                     replace("\9","\\9").\
                      replace("\n", "\\n").\
                      replace("\t", "\\t").\
                      replace("\f", "\\f").\


### PR DESCRIPTION
I've seen this happen with single digit numerics too,  eg "\0" gets turned into a null, not "\\\\0".