### PR TITLE
Make vmonkey.py a little more OS agnostic

### DIFF
--- a/vipermonkey/vmonkey.py
+++ b/vipermonkey/vmonkey.py
@@ -166,7 +166,7 @@ def _read_doc_text_libreoffice(data):
         return None
     
     # Save the Word data to a temporary file.
-    out_dir = "/tmp/tmp_word_file_" + str(random.randrange(0, 10000000000))
+    out_dir = tempdir + "tmp_word_file_" + str(random.randrange(0, 10000000000))
     f = open(out_dir, 'wb')
     f.write(data)
     f.close()
@@ -936,7 +936,7 @@ def load_excel_libreoffice(data):
         return None
     
     # Save the Excel data to a temporary file.
-    out_dir = "/tmp/tmp_excel_file_" + str(random.randrange(0, 10000000000))
+    out_dir = tempdir + "tmp_excel_file_" + str(random.randrange(0, 10000000000))
     f = open(out_dir, 'wb')
     f.write(data)
     f.close()
@@ -1168,7 +1168,7 @@ def _process_file (filename,
             if (only_filename is not None):
                 out_dir = artifact_dir + "/" + only_filename + "_artifacts/"
             else:
-                out_dir = "/tmp/tmp_file_" + str(random.randrange(0, 10000000000))
+                out_dir = tempdir + "tmp_file_" + str(random.randrange(0, 10000000000))
             log.info("Saving dropped analysis artifacts in " + out_dir)
             vba_context.out_dir = out_dir
             del filename # We already have this in memory, we don't need to read it again.

--- a/vipermonkey/vmonkey.py
+++ b/vipermonkey/vmonkey.py
@@ -109,6 +109,7 @@ from datetime import timedelta
 import subprocess
 import zipfile
 import io
+import distutils.spawn
 
 import prettytable
 from oletools.thirdparty.xglob import xglob
@@ -134,6 +135,23 @@ from core.logger import log
 from core.logger import CappedFileHandler
 from logging import LogRecord
 from logging import FileHandler
+
+tempdir = tempfile.gettempdir()
+
+if os.name == "nt":
+    if ("Python3") in distutils.spawn.find_executable("python.exe"):
+        python = distutils.spawn.find_executable("python.exe")
+    elif ("Python2") in distutils.spawn.find_executable("python.exe"):
+        print("Can't find python3 - make sure it's installed, then try again.")
+        sys.exit()
+elif os.name == "posix":
+    if ("python3") in distutils.spawn.find_executable("python3"):
+        python = distutils.spawn.find_executable("python3")
+    elif ("python3") in distutils.spawn.find_executable("python"):
+        python = distutils.spawn.find_executable("python3")
+    elif ("python3") not in distutils.spawn.find_executable("python") and ("python3") not in distutils.spawn.find_executable("python3"):
+        print("Can't find python3 - make sure it's installed, then try again.")
+        sys.exit()
 
 # === MAIN (for tests) ===============================================================================================
 


### PR DESCRIPTION
- Made temp file location OS independent - temp files were originally saved to /tmp, but this doesn't work so well if ViperMonkey is installed to FLARE VM.
- Added a check for python3 binary location, just in case python3 was installed using the command alias "python" rather than "python3" as was the case in my FLARE VM. This is a bit janky and could probably benefit from a better coder cleaning it up.