### PR TITLE
Add own Dockerfile & build if image doesn't exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM pypy:2
+
+WORKDIR /opt
+
+COPY . ./ViperMonkey
+
+RUN apt update -yqq && \
+    apt install -yqq --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc-dev \
+        libssl-dev
+
+RUN cd ViperMonkey && \
+    pip install -U -r requirements.txt && \
+    pip install pyparsing && \
+    apt remove -y gcc libc-dev libssl-dev unzip wget && \
+    rm -rf /var/lib/apt/lists/* /usr/share/doc && \
+    rm -rf /usr/local/share/man /var/cache/debconf/*-old
+
+WORKDIR /malware
+CMD [ "bash" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,27 @@
+FROM pypy:2
+
+WORKDIR /opt
+
+RUN apt update -yqq && \
+    apt upgrade -yqq && \
+    apt install -yqq --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc-dev \
+        libssl-dev \
+        unzip \
+        libimage-exiftool-perl \
+        wget && \
+    wget https://github.com/chezwicker/ViperMonkey/archive/refs/heads/master.zip && \
+    unzip master.zip && \
+    rm master.zip && \
+    mv ViperMonkey-master ViperMonkey && \
+    cd ViperMonkey && \
+    pip install -U -r requirements.txt && \
+    pip install pyparsing && \
+    apt remove -y gcc libc-dev libssl-dev unzip wget && \
+    rm -rf /var/lib/apt/lists/* /usr/share/doc && \
+    rm -rf /usr/local/share/man /var/cache/debconf/*-old
+
+WORKDIR /malware
+CMD [ "bash" ]

--- a/docker/dockermonkey.sh
+++ b/docker/dockermonkey.sh
@@ -32,13 +32,8 @@ if [[ $(docker ps -f status=running -f ancestor=$tag -l | tail -n +2) ]]; then
         echo "[+] Other ViperMonkey containers are running!"
 fi
 
-if [ "$(docker images -q $tag:latest 2> /dev/null)" == "" ]; then
-    echo "[*] Building image $tag..."
-    pushd $(dirname "$0")/..
-    docker build . -t $tag
-    popd
-fi
-echo "[*] Starting container..."
+echo "[*] Building and starting container..."
+docker build . -t $tag
 docker_id=$(docker run --rm -d -t $tag:latest)
 
 echo "[*] Attempting to copy file $1 into container ID $docker_id"
@@ -80,7 +75,7 @@ if [[ $# -ge 4 && $3 == "-i" ]]; then
 fi
 
 # Run ViperMonkey in the docker container.
-docker exec $docker_id sh -c "/opt/ViperMonkey/vipermonkey/vmonkey.py -s --ioc --jit '/root/$file_basename' $json $entry"
+docker exec $docker_id sh -c "/opt/ViperMonkey/vipermonkey/vmonkey.py -s --ioc '/root/$file_basename' $json $entry"
 
 # Copy out the JSON analysis report if needed.
 if [ "$json_file" != "" ]; then

--- a/docker/dockermonkey.sh
+++ b/docker/dockermonkey.sh
@@ -34,7 +34,7 @@ fi
 
 if [ "$(docker images -q $tag:latest 2> /dev/null)" == "" ]; then
     echo "[*] Building image $tag..."
-    pushd ..
+    pushd $(dirname "$0")/..
     docker build . -t $tag
     popd
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyparsing==2.2.0 # pyparsing 2.4.0 triggers a MemoryError on some samples (issue
 xlrd2
 xlrd
 unidecode
-regex
+regex<2022.1.18


### PR DESCRIPTION
The referenced docker image is behind the current state (at the moment, e.g. the `--jit` option doesn't work).

This change adds a local Dockerfile (derived from https://hub.docker.com/r/reuteras/vipermonkey/dockerfile) and adjusts `dockermonkey.sh` to uses it.

If the given image exists locally, it will be used as is. If it doesn't, it will be built from the Dockerfile.